### PR TITLE
【管理者を登録する】(1-2)初級 入力値エラー処理を行うように修正しました。

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -72,7 +73,12 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@RequestMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form,BindingResult result) {
+		
+		if(result.hasErrors()) {
+			return toInsert();
+		}
+		
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
+++ b/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
@@ -1,5 +1,9 @@
 package jp.co.sample.emp_management.form;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 /**
  * 管理者情報登録時に使用するフォーム.
  * 
@@ -8,10 +12,16 @@ package jp.co.sample.emp_management.form;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank(message="氏名は必ず入力してください。")
 	private String name;
+	
 	/** メールアドレス */
+	@NotBlank(message="メールアドレスは必ず入力してください。")
+	@Email(message="メールアドレスの形式が不正です。")
 	private String mailAddress;
+
 	/** パスワード */
+	@Pattern(regexp="^([a-zA-Z0-9]{8,})$",message="パスワードは8文字以上の英数字で入力してください。")
 	private String password;
 
 	/**


### PR DESCRIPTION
(1-2)初級 ログイン画面において、入力値エラー処理を行うように修正しました。
・氏名　空白なし
・メールアドレス　空白なし、メールアドレスの形式
・パスワード　空白なし、8文字以上、英数字(英字・数字のみも可)