### PR TITLE
(1-3)中級 Eメール重複チェックに対応

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -73,7 +73,7 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@RequestMapping("/insert")
-	public String insert(@Validated InsertAdministratorForm form,BindingResult result) {
+	public String insert(@Validated InsertAdministratorForm form,BindingResult result,Model model) {
 		
 		if(result.hasErrors()) {
 			return toInsert();
@@ -82,8 +82,16 @@ public class AdministratorController {
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
-		administratorService.insert(administrator);
-		return "redirect:/";
+		
+		try {
+			administratorService.insert(administrator);
+			return "redirect:/";
+		} catch (Exception e) {
+			System.out.println(e.getMessage());
+			model.addAttribute("emailErrorMessage", e.getMessage());
+			return toInsert();
+		}
+		
 	}
 
 	/////////////////////////////////////////////////////

--- a/src/main/java/jp/co/sample/emp_management/service/AdministratorService.java
+++ b/src/main/java/jp/co/sample/emp_management/service/AdministratorService.java
@@ -24,9 +24,18 @@ public class AdministratorService {
 	 * 管理者情報を登録します.
 	 * 
 	 * @param administrator 管理者情報
+	 * @throws Exception メールアドレスの重複
 	 */
-	public void insert(Administrator administrator) {
-		administratorRepository.insert(administrator);
+	public void insert(Administrator administrator) throws Exception {
+		
+		// 
+		boolean isNotExistInDB = (administratorRepository.findByMailAddress(administrator.getMailAddress())==null); 
+		
+		if(isNotExistInDB) {
+			administratorRepository.insert(administrator);
+		} else {
+			throw new Exception("このメールアドレスは既に使用されています。");
+		}
 	}
 	
 	/**

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -34,6 +34,9 @@
 					<form method="post" action="login.html" th:action="@{/insert}" th:object="${insertAdministratorForm}">
 						<fieldset>
 							<legend>管理者登録<br>(システムにログインできる管理者を登録します)</legend>
+						<div class="alert alert-danger" th:if="${emailErrorMessage}!=null">
+                       		<p th:text="${emailErrorMessage}"></p>
+	                    </div>
 							<!-- 氏名 -->
 							<div class="form-group">
 								<div class="row">
@@ -53,7 +56,7 @@
 							<div class="form-group">
 								<div class="row">
 									<div class="col-sm-12">
-										<label for="mailAddress">
+					                    <label for="mailAddress">
 											メールアドレス:
 										</label>
 										<label th:if="${#fields.hasErrors('mailAddress')}" th:errors="*{mailAddress}" class="error-messages">


### PR DESCRIPTION
# what
お客様からの要望機能追加対応
(1-3)中級 Eメール重複チェック
既に登録されているEメールアドレスを登録しようとすると500というエラー画面が出てしまうので、改修して欲しい

# why　
管理者登録時、入力されたアドレスが既にデータベースにある場合は管理者登録画面に戻り、「このメールアドレスは既に使用されています。」と表示するようにしました。