### PR TITLE
Develop

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/common/GlobalExceptionHandler.java
+++ b/src/main/java/jp/co/sample/emp_management/common/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package jp.co.sample.emp_management.common;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+public class GlobalExceptionHandler implements HandlerExceptionResolver {
+
+	private static final Logger LOGGER = 
+			LoggerFactory.getLogger(GlobalExceptionHandler.class);
+	
+		@Override
+		public ModelAndView resolveException(HttpServletRequest request,
+				javax.servlet.http.HttpServletResponse response, Object handler, java.lang.Exception ex) {
+			LOGGER.error("システムエラーが発生しました！",ex);
+			return null;
+		}
+
+}

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorApiController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorApiController.java
@@ -1,0 +1,32 @@
+package jp.co.sample.emp_management.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+public class AdministratorApiController {
+
+	@ResponseBody
+	@RequestMapping(value = "/checkConPass", method = RequestMethod.POST)
+	public Map<String, String> checkConPass(String password, String confirmPassword) {
+		
+		Map<String, String> map = new HashMap<>();
+		String duplicateMessage = null;
+		if (confirmPassword.isBlank()) {
+			duplicateMessage = "確認用パスワードが空欄です";
+		}else if (confirmPassword.equals(password)) {
+			duplicateMessage = "確認用パスワード入力OK!";
+		} else {
+			duplicateMessage = "確認用パスワードとパスワードが一致していません";
+		}
+		map.put("duplicateMessage", duplicateMessage);
+		return map;
+	}
+
+}

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -129,6 +129,8 @@ public class AdministratorController {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です。");
 			return toLogin();
 		}
+		
+		session.setAttribute("administratorName", administrator.getName());
 		return "forward:/employee/showList";
 	}
 	

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -79,6 +79,12 @@ public class AdministratorController {
 			return toInsert();
 		}
 		
+		//　パスワードと確認用パスワードが一致しない場合に入力画面へリターン
+		if(!form.getPassword().equals(form.getComfirmPassword())) {
+			model.addAttribute("passwordErrorMessage", "パスワードと登録用パスワードが一致していません。");
+			return toInsert();
+		}
+		
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -80,7 +80,7 @@ public class AdministratorController {
 		}
 		
 		//　パスワードと確認用パスワードが一致しない場合に入力画面へリターン
-		if(!form.getPassword().equals(form.getComfirmPassword())) {
+		if(!form.getPassword().equals(form.getConfirmPassword())) {
 			model.addAttribute("passwordErrorMessage", "パスワードと登録用パスワードが一致していません。");
 			return toInsert();
 		}

--- a/src/main/java/jp/co/sample/emp_management/controller/EmployeeController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/EmployeeController.java
@@ -55,6 +55,29 @@ public class EmployeeController {
 
 	
 	/////////////////////////////////////////////////////
+	// ユースケース：従業員から名前の「含む検索」を行う
+	/////////////////////////////////////////////////////
+	/**
+	 * 従業員一覧画面に、検索結果を出力します.
+	 * 
+	 * @param model モデル
+	 * @return 従業員一覧画面
+	 */
+	@RequestMapping("/searchByName")
+	public String searchByName(String name,Model model) {
+		List<Employee> employeeList = employeeService.searchByName(name);
+
+		if(employeeList.size() == 0) {
+			model.addAttribute("message", "１件もありませんでした");
+			employeeList = employeeService.showList();
+		}
+		
+		model.addAttribute("employeeList", employeeList);
+		return "employee/list";
+	}
+	
+	
+	/////////////////////////////////////////////////////
 	// ユースケース：従業員詳細を表示する
 	/////////////////////////////////////////////////////
 	/**

--- a/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
+++ b/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
@@ -12,17 +12,21 @@ import javax.validation.constraints.Pattern;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
-	@NotBlank(message="氏名は必ず入力してください。")
+	@NotBlank(message = "氏名は必ず入力してください。")
 	private String name;
-	
+
 	/** メールアドレス */
-	@NotBlank(message="メールアドレスは必ず入力してください。")
-	@Email(message="メールアドレスの形式が不正です。")
+	@NotBlank(message = "メールアドレスは必ず入力してください。")
+	@Email(message = "メールアドレスの形式が不正です。")
 	private String mailAddress;
 
 	/** パスワード */
-	@Pattern(regexp="^([a-zA-Z0-9]{8,})$",message="パスワードは8文字以上の英数字で入力してください。")
+	@Pattern(regexp = "^([a-zA-Z0-9]{8,})$", message = "パスワードは8文字以上の英数字で入力してください。")
 	private String password;
+
+	/** 確認用パスワード */
+	@Pattern(regexp = "^([a-zA-Z0-9]{8,})$", message = "確認用パスワードは8文字以上の英数字で入力してください。")
+	private String comfirmPassword;
 
 	/**
 	 * @return the name
@@ -65,11 +69,19 @@ public class InsertAdministratorForm {
 	public void setPassword(String password) {
 		this.password = password;
 	}
-	
+
+	public String getComfirmPassword() {
+		return comfirmPassword;
+	}
+
+	public void setComfirmPassword(String comfirmPassword) {
+		this.comfirmPassword = comfirmPassword;
+	}
+
 	@Override
 	public String toString() {
 		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ "]";
+				+ ", comfirmPassword=" + comfirmPassword + "]";
 	}
-	
+
 }

--- a/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
+++ b/src/main/java/jp/co/sample/emp_management/form/InsertAdministratorForm.java
@@ -26,7 +26,7 @@ public class InsertAdministratorForm {
 
 	/** 確認用パスワード */
 	@Pattern(regexp = "^([a-zA-Z0-9]{8,})$", message = "確認用パスワードは8文字以上の英数字で入力してください。")
-	private String comfirmPassword;
+	private String confirmPassword;
 
 	/**
 	 * @return the name
@@ -70,18 +70,18 @@ public class InsertAdministratorForm {
 		this.password = password;
 	}
 
-	public String getComfirmPassword() {
-		return comfirmPassword;
+	public String getConfirmPassword() {
+		return confirmPassword;
 	}
 
-	public void setComfirmPassword(String comfirmPassword) {
-		this.comfirmPassword = comfirmPassword;
+	public void setConfirmPassword(String confirmPassword) {
+		this.confirmPassword = confirmPassword;
 	}
 
 	@Override
 	public String toString() {
 		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ ", comfirmPassword=" + comfirmPassword + "]";
+				+ ", confirmPassword=" + confirmPassword + "]";
 	}
 
 }

--- a/src/main/java/jp/co/sample/emp_management/repository/AdministratorRepository.java
+++ b/src/main/java/jp/co/sample/emp_management/repository/AdministratorRepository.java
@@ -58,8 +58,8 @@ public class AdministratorRepository {
 	 * @return 管理者情報 存在しない場合はnullを返します
 	 */
 	public Administrator findByMailAddressAndPassward(String mailAddress, String password) {
-		String sql = "select id,name,mail_address,password from administrators where mail_address= '" + mailAddress + "' and password='" + password + "'";
-		SqlParameterSource param = new MapSqlParameterSource();
+		String sql = "select id,name,mail_address,password from administrators where mail_address= :mailAddress and password='" + password + "'";
+		SqlParameterSource param = new MapSqlParameterSource().addValue("mailAddress", mailAddress);
 		List<Administrator> administratorList = template.query(sql, param, ADMINISTRATOR_ROW_MAPPER);
 		if (administratorList.size() == 0) {
 			return null;

--- a/src/main/java/jp/co/sample/emp_management/repository/EmployeeRepository.java
+++ b/src/main/java/jp/co/sample/emp_management/repository/EmployeeRepository.java
@@ -50,7 +50,7 @@ public class EmployeeRepository {
 	 * @return 全従業員一覧 従業員が存在しない場合はサイズ0件の従業員一覧を返します
 	 */
 	public List<Employee> findAll() {
-		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees";
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees ORDER BY hire_date ASC";
 
 		List<Employee> developmentList = template.query(sql, EMPLOYEE_ROW_MAPPER);
 

--- a/src/main/java/jp/co/sample/emp_management/repository/EmployeeRepository.java
+++ b/src/main/java/jp/co/sample/emp_management/repository/EmployeeRepository.java
@@ -75,6 +75,21 @@ public class EmployeeRepository {
 	}
 
 	/**
+	 * 入力された名前を含む従業員を検索し、該当する従業員情報を取得します。
+	 * 
+	 * @param name　検索したい名前の一部
+	 * @return 検索された従業員情報
+	 */
+	public List<Employee> findByName(String name) {
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees WHERE name like :name ORDER BY hire_date ASC";
+		
+		SqlParameterSource param = new MapSqlParameterSource().addValue("name", "%"+name+"%");
+		List<Employee> developmentList = template.query(sql,param, EMPLOYEE_ROW_MAPPER);
+
+		return developmentList;
+	}
+	
+	/**
 	 * 従業員情報を変更します.
 	 */
 	public void update(Employee employee) {

--- a/src/main/java/jp/co/sample/emp_management/service/EmployeeService.java
+++ b/src/main/java/jp/co/sample/emp_management/service/EmployeeService.java
@@ -32,6 +32,12 @@ public class EmployeeService {
 		return employeeList;
 	}
 	
+	public List<Employee> searchByName(String name) {
+		List<Employee> employeeList = employeeRepository.findByName(name);
+		return employeeList;
+	}
+	
+	
 	/**
 	 * 従業員情報を取得します.
 	 * 

--- a/src/main/resources/static/js/insert.js
+++ b/src/main/resources/static/js/insert.js
@@ -1,9 +1,52 @@
 'use strict'
 
 $(function(){
+	$(document).on('keyup','#password',function(){
+		checkPass()	
+	});
+	
+	$(document).on('keyup','#confirmPassword',function(){
+		checkPass()	
+	});
+	
+
+
+function checkPass(){
+		let hostUrl = "http://localhost:8080/checkConPass";
+		let password = $('#password').val();
+		let confirmPassword = $('#confirmPassword').val();
+		
+		$.ajax({
+			url : hostUrl,
+			type : 'post',
+			dataType : 'json',
+			data :{
+				password : password,
+				confirmPassword : confirmPassword,
+			},
+			async : true ,
+		}).done(function(data){
+			// コンソールに取得データを表示
+			console.log(data);
+			console.dir(JSON.stringify(data));
+			console.log(data.duplicateMessage);
+			$('#duplicateMessage').text(data.duplicateMessage);
+		}).fail(function(XMLHttpRequest,textStatus,errorThrown){
+			alert('エラーが発生しました！')
+			console.log('XMLHttpRequest : ' + XMLHttpRequest.status);
+			console.log('textStatus : ' + textStatus);
+			console.log('errorThrown : ' + errorThrown.message);
+		})
+	};
+	
 	$('#register').on('click',function(){
 		$('#register').prop('disabled',true);
 //		console.log('ボタンを止めました！');
 		$('#insertAdministrator').submit();
 	});
+	
+	
+	
 });
+	
+	

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -37,6 +37,9 @@
 						<div class="alert alert-danger" th:if="${emailErrorMessage}!=null">
                        		<p th:text="${emailErrorMessage}"></p>
 	                    </div>
+						<div class="alert alert-danger" th:if="${passwordErrorMessage}!=null">
+                       		<p th:text="${passwordErrorMessage}"></p>
+	                    </div>
 							<!-- 氏名 -->
 							<div class="form-group">
 								<div class="row">
@@ -82,18 +85,31 @@
 									</div>
 								</div>
 							</div>
+							<!-- 確認用パスワード -->
+							<div class="form-group">
+								<div class="row">
+									<div class="col-sm-12">
+										<label for="comfirmPassword">
+											パスワード:
+										</label>
+										<label th:if="${#fields.hasErrors('comfirmPassword')}" th:errors="*{comfirmPassword}" class="error-messages">
+											パスワードを入力してください
+										</label>
+										<input type="password" name="comfirmPassword" id="comfirmPassword" class="form-control" placeholder="password"
+											 th:field="*{comfirmPassword}" th:errorclass="error-input" value="xxxxxxxx">
+									</div>
+								</div>
+							</div>
 							<!-- 登録ボタン -->
 							<div class="form-group">
 								<div class="row">
 									<div class="col-sm-12">
-										<button type="submit" class="btn btn-primary" id="register">登録</button>
-<!-- 										<button type="button" class="btn btn-primary" id="register">登録</button> -->
+										<button type="button" class="btn btn-primary" id="register">登録</button>
 									</div>
 								</div>
 							</div>
 						</fieldset>
 					</form>
-
 
 
 <!-- ここから下を編集する必要はありません -->

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -89,14 +89,15 @@
 							<div class="form-group">
 								<div class="row">
 									<div class="col-sm-12">
-										<label for="comfirmPassword">
+										<label for="confirmPassword">
 											パスワード:
 										</label>
-										<label th:if="${#fields.hasErrors('comfirmPassword')}" th:errors="*{comfirmPassword}" class="error-messages">
+										<label th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}" class="error-messages">
 											パスワードを入力してください
 										</label>
-										<input type="password" name="comfirmPassword" id="comfirmPassword" class="form-control" placeholder="password"
-											 th:field="*{comfirmPassword}" th:errorclass="error-input" value="xxxxxxxx">
+										<span id="duplicateMessage" class="error-messages"></span>
+										<input type="password" name="confirmPassword" id="confirmPassword" class="form-control" placeholder="password"
+											 th:field="*{confirmPassword}" th:errorclass="error-input" value="xxxxxxxx">
 									</div>
 								</div>
 							</div>
@@ -110,7 +111,6 @@
 							</div>
 						</fieldset>
 					</form>
-
 
 <!-- ここから下を編集する必要はありません -->
 				</div>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -40,7 +40,7 @@
 						<li class="active"><a href="list.html" th:href="@{/employee/showList}">従業員管理</a></li>
 					</ul>
 					<p class="navbar-text navbar-right">
-					   <span th:text="${administratorName}">山田太郎</span>さんこんにちは！
+					   <span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！
 						&nbsp;&nbsp;&nbsp;
 						<a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
 					</p>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -101,7 +101,7 @@
 							      入社日
 							    </th>
 							    <td>
-							      <span th:utext="${employee.hireDate}">2012/11/29</span>
+							      <span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012年11月29日</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -142,6 +142,7 @@
 							    </th>
 							    <td>
 							      <span th:utext="${employee.salary + '円'}">400000円</span>
+<!-- 							      <span th:utext="${#numbers.formatInteger(employee.salary,1,'COMMA') + '円'}">400000円</span> -->
 							    </td>
 							  </tr>
 							  <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -78,7 +78,7 @@
 							      従業員名
 							    </th>
 							    <td>
-							     <span th:utext="${employee.name}">山田花子</span>
+							     <span th:text="${employee.name}">山田花子</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -94,7 +94,7 @@
 							      性別
 							    </th>
 							    <td>
-							      <span th:utext="${employee.gender}">女性</span>
+							      <span th:text="${employee.gender}">女性</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -102,7 +102,7 @@
 							      入社日
 							    </th>
 							    <td>
-							      <span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012年11月29日</span>
+							      <span th:text="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012年11月29日</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -110,7 +110,7 @@
 							      メールアドレス
 							    </th>
 							    <td>
-							      <span th:utext="${employee.mailAddress}">yamada@sample.com</span>
+							      <span th:text="${employee.mailAddress}">yamada@sample.com</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -118,7 +118,7 @@
 							      郵便番号
 							    </th>
 							    <td>
-							      <span th:utext="${employee.zipCode}">111-1111</span>
+							      <span th:text="${employee.zipCode}">111-1111</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -126,7 +126,7 @@
 							      住所
 							    </th>
 							    <td>
-							      <span th:utext="${employee.address}">東京都新宿区1-1-1</span>
+							      <span th:text="${employee.address}">東京都新宿区1-1-1</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -134,7 +134,7 @@
 							      電話番号
 							    </th>
 							    <td>
-							      <span th:utext="${employee.telephone}">090-0000-0000</span>
+							      <span th:text="${employee.telephone}">090-0000-0000</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -142,7 +142,7 @@
 							      給料
 							    </th>
 							    <td>
-							      <span th:utext="${#numbers.formatInteger(employee.salary,1,'COMMA') + '円'}">400000円</span>
+							      <span th:text="${#numbers.formatInteger(employee.salary,1,'COMMA') + '円'}">400000円</span>
 							    </td>
 							  </tr>
 							  <tr>
@@ -150,7 +150,7 @@
 							      特性
 							    </th>
 							    <td>
-							      <span th:utext="${employee.characteristics}">明るく素直な性格です。リーダーシップを発揮します。新卒社員研修の時はグループ開発の時にリーダーを買ってでました。積極性も人間性も抜群です。周りに対する不満も聞いたことがありません。</span>
+							      <span th:text="${employee.characteristics}">明るく素直な性格です。リーダーシップを発揮します。新卒社員研修の時はグループ開発の時にリーダーを買ってでました。積極性も人間性も抜群です。周りに対する不満も聞いたことがありません。</span>
 							    </td>
 							  </tr>
 							  <tr>

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -52,7 +52,8 @@
 
 		<!-- パンくずリスト -->
 		<ol class="breadcrumb">
-			<li>従業員リスト</li>
+			<li><a th:href="@{/employee/showList}">従業員リスト</a></li>
+<!-- 			<li>従業員リスト</li> -->
 			<li class="active">従業員詳細</li>
 		</ol>
 		

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -141,8 +141,7 @@
 							      給料
 							    </th>
 							    <td>
-							      <span th:utext="${employee.salary + '円'}">400000円</span>
-<!-- 							      <span th:utext="${#numbers.formatInteger(employee.salary,1,'COMMA') + '円'}">400000円</span> -->
+							      <span th:utext="${#numbers.formatInteger(employee.salary,1,'COMMA') + '円'}">400000円</span>
 							    </td>
 							  </tr>
 							  <tr>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -40,7 +40,7 @@
 						<li class="active"><a href="list.html" th:href="@{/employee/showList}">従業員管理</a></li>
 					</ul>
 					<p class="navbar-text navbar-right">
-						<span th:text="${administratorName}">山田太郎</span>さんこんにちは！
+						<span th:text="${session.administratorName}">山田太郎</span>さんこんにちは！
 						&nbsp;&nbsp;&nbsp;
 						<a href="../administrator/login.html" class="navbar-link" th:href="@{/logout}">ログアウト</a>
 					</p>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -63,7 +63,13 @@
 <!-- ここから上を編集する必要はありません -->
 
 <!-- ここにモックのtable要素を貼り付けます -->
-
+		<div class="searchEmployeeForm">
+			<form th:action="@{/employee/searchByName}" method="post" id="searchEmployeeForm">
+				<input type="text" name="name">
+				<button>を含む従業員を検索</button>
+			</form>
+			<span th:if="${message}" th:text="${message}"></span>
+		</div>
 				<table class="table table-striped">
 					<thead>
 						<tr>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -80,7 +80,7 @@
 								</a>
 							</td>
 							<td>
-								<span th:text="${employee.hireDate}">2016/12/1</span>
+								<span th:utext="${#dates.format(employee.hireDate, 'yyyy年MM月dd日')}">2012年11月29日</span>
 							</td>
 							<td>
 								<span th:text="${employee.dependentsCount} + '人'">3人</span>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<link href="" rel="stylesheets">
+<title>404 Not Found</title>
+</head>
+<body>
+<h2>404 Not Found</h2>
+お探しのページは見つかりませんでした。
+
+</body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<link href="" rel="stylesheets">
+<title>メンテナンス中</title>
+</head>
+<body>
+<h2>メンテナンス中</h2>
+現在メンテナンス中です。
+ご迷惑をおかけしており申し訳ございません。
+
+</body>
+</html>


### PR DESCRIPTION
# what
お客様からの要望機能追加対応

> (1-5)中級 確認用パスワード
> 　パスワードを忘れてしまったという問い合わせが殺到しているため、
> 　確認用パスワード欄をつけてパスワード入力ミスを防いで欲しい。

> (2-1)中級 ログイン者名表示
> 　ログイン後、従業員一覧画面と従業員詳細画面に「〇〇さん　こんにちは！」と表示させたいが表示されない。
> 　直して欲しい。

> (3-1)初級 従業員一覧の並び順
> 従業員の並びが一定でない。毎回同じ並び順で表示させて欲しい。
> この時、機械的にIDで並び変えるのではなく、どのような並び順が使いやすいか等も考えられると良い。 

> (4-1)初級 日付フォーマット
> 入社日の表記を「2015年05月01日」というフォーマットに変えて欲しい。

> (4-2)初級 価格フォーマット
> 給料の表記を「233,800円」というように適切な場所にカンマを入れて欲しい。

> (4-3)中級 パンくずリスト修正
> 従業員一覧に戻るパンくずリストのリンクが切れているので修正してほしい。

> (5-1)中級 SQL Injection
> (5-2)中級 XSS
> セキュリティ診断会社にサイトのセキュリティチェックをお願いしたところ、SQLインジェクションとクロスサイトスクリプティングの脆弱性が１ヶ所ずつ見つかったという報告書が来たので、該当箇所を探し修正して欲しい。

> (6-1)中級 実務的エラー処理
> 現在、サーバ側でエラー(404,500)が出た際に画面に「Whitelabel Error Page」が表示されてしまう。
> これだと問題なので、実務的エラー処理を入れて、「ページが見つかりません」や「メンテナンス中」であることの画面を表示させて欲しい。

> (6-2)中級 従業員曖昧検索
> 従業員一覧画面に従業員名で曖昧検索するための検索フォームを用意して曖昧検索機能を設けて欲しい。
> 仕様
> 　・空文字で検索した場合
> 　　→全件検索結果を表示させる
> 　・指定した文字列が存在しなかった場合
> 　　→「１件もありませんでした」というメッセージと共に全件検索結果を表示させる
> 　　※ユーザの使いやすさを考えた結果このような仕様にしました

# why

> (1-5)　管理者登録画面に確認用パスワード欄を設けました。
> 非同期でパスワード欄と確認用パスワード欄の入力内容を確認し、異なる場合はエラーメッセージを表示するようにしました。

> (2-1)　ログイン時に、管理者名をセッションスコープに格納するように機能追加しました。
> それに沿って、detail.html,list.htmlの2つで、管理者名をセッションスコープから呼び出すように変更しました。

> (3-1)　EmployeeRepositoryのfindAllメソッドにORDER BY句を追加、入社日の昇順で並び替えました。

> (4-1)　list.htmlとdetail.htmlの日付欄に「#dates.format()」を挿入、日付をフォーマットしました。

> (4-2)　detail.htmlのsalary表示部分に、「#numbers.formatInteger()」を挿入、カンマ表示ができるように変更しました。

> (4-3)　detail.htmlのパンくずリストの従業員一覧を<a>タグで囲み、従業員一覧へリンクを行いました。

> (5-1)　AdministratorRepositoryのfindByMailAddressにおいて、プレースホルダーを使った方式のSQL文に変更しました。
> (5-2)　detail.htmlの「th:utext」を「th:text」に変更しました。

> (6-1)
> 共通：templateフォルダ内にerrorフォルダを作成。
> 404エラー：errorフォルダ内に404.htmlを作成。
> 500エラー：errorフォルダ内に500.htmlを作成。またルートパッケージ内にGlobalExceptionHandlerを作成。

> (6-2)
> list.htmlに検索フォームと検索結果が0件の時のメッセージ表示枠を追加しました。
> EmployeeRepositoryにfindByNameメソッドを、
> EmployeeServiceとEmployeeControllerにsearchByNameメソッドを追加しました。
> 